### PR TITLE
created withdraw check

### DIFF
--- a/contracts/Distributor.sol
+++ b/contracts/Distributor.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.7.5;
 
-import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
-import "openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 
 
 contract Distributor {

--- a/contracts/NativeMetaTransaction.sol
+++ b/contracts/NativeMetaTransaction.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.7.5;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
 import "./EIP712Base.sol";
 
 contract NativeMetaTransaction is EIP712Base {

--- a/package-lock.json
+++ b/package-lock.json
@@ -223,6 +223,11 @@
         "@ethersproject/strings": "^5.0.8"
       }
     },
+    "@openzeppelin/contracts": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.0.tgz",
+      "integrity": "sha512-qh+EiHWzfY/9CORr+eRUkeEUP1WiFUcq3974bLHwyYzLBUtK6HPaMkIUHi74S1rDTZ0sNz42DwPc5A4IJvN3rg=="
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -4523,6 +4528,32 @@
         "underscore": "1.9.1",
         "web3-core-helpers": "1.2.1",
         "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "websocket": {
+          "version": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
+          "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+          "requires": {
+            "debug": "^2.2.0",
+            "es5-ext": "^0.10.50",
+            "nan": "^2.14.0",
+            "typedarray-to-buffer": "^3.1.5",
+            "yaeti": "^0.0.6"
+          }
+        }
       }
     },
     "web3-shh": {

--- a/package.json
+++ b/package.json
@@ -7,13 +7,14 @@
     "test": "test"
   },
   "dependencies": {
+    "@openzeppelin/contracts": "^3.4.0",
     "dotenv": "^6.2.0",
     "glob": "^7.1.3",
     "openzeppelin-solidity": "3.3.0",
     "openzeppelin-test-helpers": "^0.2.0",
+    "truffle": "5.1.56",
     "truffle-hdwallet-provider": "^1.0.5",
-    "web3": "1.3.1",
-    "truffle": "5.1.56"
+    "web3": "1.3.1"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
- Added a withdrawAllowed boolean that's set to false in the constructor
- Added a function allowWithdraw that can be called by ChildChainManager 

*Open Question* to allow for automatic withdrawals by holders from Matic to Mainnet when withdrawAllowed == true, do we need to change the deposit() function to a public function that can only be called by DEPOSITOR_ROLE (at any time) or a holder when withdrawAllowed == true...I think this is the case, but wanted to run it by you @pranavdaa 
